### PR TITLE
Removido obrigatoriedade do endereço de entrega

### DIFF
--- a/src/pagseguro.js
+++ b/src/pagseguro.js
@@ -18,7 +18,8 @@ const pagseguro = function(params) {
         token: this.token,
         mode: this.mode,
         currency: this.currency,
-        url: this.url
+        url: this.url,
+        shippingAddressRequired: false
     }
 
     this.items = [];
@@ -47,6 +48,7 @@ pagseguro.prototype.setShipping = function(shipping) {
     this.checkoutData.shippingAddressState = shipping.state;
     this.checkoutData.shippingAddressPostalCode = shipping.postal_code;
     this.checkoutData.shippingAddressCountry = shipping.country || 'BRA';
+    this.checkoutData.shippingAddressRequired = shipping.required;
 
     if (shipping.same_for_billing) {
         this.setBilling(shipping);


### PR DESCRIPTION
Foi acrescentado um parâmetro pra não obrigar o preenchimento do endereço de entrega.
Muita gente presta serviço e não tem necessidade dessas informações.