### PR TITLE
Correção do noInterestInstallmentQuantity

### DIFF
--- a/src/pagseguro.js
+++ b/src/pagseguro.js
@@ -87,11 +87,11 @@ pagseguro.prototype.addItem = function(item) {
 pagseguro.prototype.sendTransaction = function(transaction, cb) {
     this.checkoutData.paymentMethod = transaction.method;
     this.checkoutData.installmentQuantity = transaction.installments || 1;
-    this.checkoutData.installmentValue = (transaction.value / transaction.installments).toFixed(2);
+    this.checkoutData.installmentValue = transaction.installmentValue;
     this.checkoutData.senderHash = transaction.hash;
 
-    if (transaction.installments && transaction.installments > 1) {
-        this.checkoutData.noInterestInstallmentQuantity = transaction.installments;
+    if (transaction.noInterestInstallmentQuantity) {
+        this.checkoutData.noInterestInstallmentQuantity = transaction.noInterestInstallmentQuantity;
     }
 
     if (this.checkoutData.paymentMethod == 'creditCard') {


### PR DESCRIPTION
Com essa correção é possível cobrar a taxa de juros do cartão do comprador ao invés de cobrar sempre do vendedor.